### PR TITLE
Minor updates to README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -31,13 +31,13 @@ if (!require("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 BiocManager::install(version = "3.19")
 
-# Install Development Version of molevolvR
+# Install Development Version of MolEvolvR
 BiocManager::install("JRaviLab/MolEvolvR")
 ```
 
 ### Loading the package
 ```{r eval=FALSE}
-library(molevolvR)
+library(MolEvolvR)
 ```
 
 ## Example
@@ -45,7 +45,7 @@ library(molevolvR)
 This is a basic example which shows you how to analyze your favorite protein:
 
 ```{r example, eval=FALSE}
-library(molevolvR)
+library(MolEvolvR)
 ## basic example code
 ## TBA
 ```


### PR DESCRIPTION
This updates the .Rmd slightly so users can strictly copy text from the README. 

Changed `library(molevolvR)` to `library(MolEvolvR)` to reflect the way the installed package is actually recognized. Whether to retain this capitalization is a separate discussion, but if a user copies "library(molevolvR)" verbatim and runs it, it will fail to load, as below.

`> library(molevolvR)
Error in library(molevolvR) : there is no package called ‘molevolvR’`